### PR TITLE
Update clubChart and clubList components to use correct colors and sort by member count

### DIFF
--- a/frontend/components/clubChart.tsx
+++ b/frontend/components/clubChart.tsx
@@ -21,8 +21,8 @@ const clubColors: { [key: string]: string } = {
   Konfederacja: "#1A1A1A",
   "Polska 2050": "#FCD300",
   "Kukiz'15": "#000000",
-  "PSL-TD": "#009FE3",
-  "Polska2050-TD": "#F091E3",
+  "PSL-TD": "#17A42B",
+  "Polska2050-TD": "#FCD300",
   // Add more clubs and their colors as needed
 };
 
@@ -58,7 +58,7 @@ const ClubsChart: React.FC<ClubsChartProps> = ({ clubs }) => {
             type: "item",
             name: "Mandaty",
             keys: ["name", "y", "color", "label"],
-            data: clubs.map((club) => [
+            data: clubs.sort((a,b) => b.membersCount - a.membersCount).map((club) => [
               club.id,
               club.membersCount,
               clubColors[club.id] || "#CCCCCC", // Use predefined color or default to gray

--- a/frontend/components/clubList.tsx
+++ b/frontend/components/clubList.tsx
@@ -11,7 +11,7 @@ interface ClubsListProps {
 const ClubsList: React.FC<ClubsListProps> = ({ clubs }) => {
   return (
     <ul className="space-y-2">
-      {clubs.map((club) => (
+      {clubs.sort((a, b) => b.membersCount - a.membersCount).map((club) => (
         <li key={club.id}>
           <Link
             href={`/club/${club.id}`}


### PR DESCRIPTION
- Update clubChart.tsx to use updated colors for political clubs
- Sort clubs in clubList.tsx by membersCount in descending order

## Checklist before requesting a review

- [x] A self-review of the code has been performed
- [x] Commit messages and code follows our `guidelines and standards`
- [x] Tests have been added or updated where appropriate
- [x] Changes generate no new errors or warnings
- [x] There are no open [Pull Requests](../../../pulls) for the same update/change

## Change Description
This PR adds sorting for parliamentary clubs in descending order by member count. It also fixes the colors of the Polska2050-TD and PSL-TD clubs. These changes were made to reflect the previous version of the site before migrating to the new tech stack.

### How Has This Been Tested?
This Pull Request was manually tested by visiting the modified version of the frontend locally. The changes were verified by:
- Inspecting the updated club color variables to ensure they are correctly applied to the chart.
- Checking the sorting functionality to confirm it works as intended.
Given the small scope of changes, extensive testing was not required.

Does this PR introduce a breaking change? **NO**
<!--- add `breaking-change` label if **YES**-->
<!--- describe the breaking change and its potential impact -->